### PR TITLE
Fix compilation issue on MinGW64

### DIFF
--- a/src/util/sexpr.h
+++ b/src/util/sexpr.h
@@ -67,7 +67,12 @@ class CVC4_PUBLIC SExpr {
   SExpr(unsigned int value);
   SExpr(unsigned long int value);
 
-  SExpr(const CVC4::Rational& value);
+#ifdef CVC4_NEED_INT64_T_OVERLOADS
+  SExpr(int64_t  value);
+  SExpr(uint64_t value);
+#endif /* CVC4_NEED_INT64_T_OVERLOADS */
+
+ SExpr(const CVC4::Rational& value);
 
   SExpr(const std::string& value);
 


### PR DESCRIPTION
  CXX      smt/smt_engine.lo
../../../../src/smt/smt_engine.cpp: In member function 'CVC4::SExpr CVC4::SmtEngine::getInfo(const string&) const':
../../../../src/smt/smt_engine.cpp:2154:0: error: call of overloaded 'SExpr(std::vector<int>::size_type)' is ambiguous
     return SExpr(d_userLevels.size());